### PR TITLE
SJ-36 - Additional changes for reduced motion

### DIFF
--- a/app/components/modal.tsx
+++ b/app/components/modal.tsx
@@ -37,7 +37,8 @@ export function Modal({
     "z-20",
     "shadow-5",
     "transition-transform",
-    "duration-500",
+    "duration-0", // If reduced motion is preferred, instant transition
+    "motion-safe:duration-500", // If no preference for reduced motion, 500ms
   ];
   return (
     <div

--- a/app/globals.css
+++ b/app/globals.css
@@ -178,10 +178,12 @@
   [class*="logo-letter-animated"] {
     --delay-step-increment: 0.25s;
     --animation-length: 3s;
-    animation: wave-y-5 var(--animation-length) ease-in-out infinite;
     /* Special more gentle animation for users with prefers-reduced-motion set */
-    @media (prefers-reduced-motion) {
-      animation: wave-y-3 var(--animation-length) ease-in-out infinite;
+    animation: wave-y-3 var(--animation-length) ease-in-out infinite;
+    /* If no preference is expressed, the full animation is displayed */
+    /* In general we write the motion-reduced variant as the default, much as xs screen size is the default */
+    @media (prefers-reduced-motion: no-preference) {
+      animation: wave-y-5 var(--animation-length) ease-in-out infinite;
     }
     animation-delay: calc(
       var(--delay-step-increment) * (var(--nth-child-index) * -1)


### PR DESCRIPTION
Some minor adjustments for prefers-reduced-motion. After a little reading I determined that best practice is to have the reduced variant as the default, which was already what we were doing in the Tailwind syntax but not in the CSS. Also, added a reduced motion variant to opening modals to make them instant. This is a good learning - it's not something I've ever encountered before!