### PR TITLE
Add -unset exstension, apply it to footer

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -38,7 +38,7 @@ export default function MainPageLayout({
         </HeaderNav>
         <HeaderNav
           label="Site controls"
-          className="fixed right-0 md:bottom-0 md:left-0"
+          className="fixed right-0 md:bottom-0 md:left-0 md:right-unset"
         >
           <ControlButtons />
         </HeaderNav>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -102,6 +102,9 @@ module.exports = {
         "75vh": "75vh",
         "80vh": "80vh",
       },
+      spacing: {
+        unset: "unset",
+      },
       strokeWidth: {
         1.5: "1.5px",
       },


### PR DESCRIPTION
Irritatingly, overlap with the footer was still an issue. Just went and added "unset" to the extension for positioning because well, sometimes you need an unset.