### PR TITLE
SJ-46 - Adjust SVG curves and padding

### DIFF
--- a/app/components/content-container.tsx
+++ b/app/components/content-container.tsx
@@ -20,6 +20,7 @@ export function ContentContainer({
     "items-center",
     "justify-center",
     "space-y-3",
+    "max-w-7xl", // Upper limit for very large screen widths
     className,
   ];
   return <div className={classNames.join(" ")}>{children}</div>;

--- a/app/components/curved-container.tsx
+++ b/app/components/curved-container.tsx
@@ -35,14 +35,28 @@ export function CurvedContainer({
     ? "drop-shadow-bottom"
     : "hidden";
 
+  const bodyTopPadding = displayTopCurve ? "pt-6" : "";
+  const bodyBottomPadding = displayBottomCurve ? "pb-6" : "";
+  const bodyClasses = [
+    "curved-container-body",
+    "relative",
+    "z-10",
+    "flex",
+    "flex-col",
+    "space-y-6",
+    "items-center",
+    "bg-[var(--theme-color-100)]",
+    "px-6",
+    bodyTopPadding,
+    bodyBottomPadding,
+  ];
+
   return (
     <div className={classNames.join(" ")}>
       <div className="relative top-1 w-full fill-[var(--theme-color-100)]">
         <CurveTop className={topCurveClasses} role="img" title="Top curve" />
       </div>
-      <div className="curved-container-body relative z-10 flex flex-col space-y-6 bg-[var(--theme-color-100)] px-6 py-2 md:py-0">
-        {children}
-      </div>
+      <div className={bodyClasses.join(" ")}>{children}</div>
       <div className="relative bottom-1 w-full fill-[var(--theme-color-100)]">
         <CurveBottom
           className={bottomCurveClasses}

--- a/app/images/curve-bottom.svg
+++ b/app/images/curve-bottom.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 200 15">
-   <title>Smooth curved section</title>
-  <path d="M309.684 12.986c-32.314.125-70.892-.591-111.61-3.203C92.306 3 .04 10.084.04 10.084L0 3V0h400v10.234s-36.46 2.545-90.316 2.752z"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 200 6"><title>Smooth curved section</title><path d="M200 6V0H0v5.69C81.828.044 154.389 2.805 200 6Z"/></svg>

--- a/app/images/curve-top.svg
+++ b/app/images/curve-top.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 200 15">
-  <title>Smooth curved section</title>
-  <path d="M309.684 2.014c-32.314-.125-70.892.591-111.61 3.203C92.306 12 .04 4.916.04 4.916L0 12v3h400V4.766s-36.46-2.545-90.316-2.752z"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 200 6"><title>Smooth curved section</title><path d="M0 0v6h200V.31C118.172 5.956 45.611 3.195 0 0Z"/></svg>


### PR DESCRIPTION
Minor adjustments here to the display of the curved sections. The padding was a bit wacky at larger sizes, and I wasn't happy with it relying on the whitespace in the SVG itself. So - the image has been chopped down in size and padding added to other elements. Easy!